### PR TITLE
Feature/auto subscription cancellation

### DIFF
--- a/frontend/src/app/api/payfast-subscribe/route.ts
+++ b/frontend/src/app/api/payfast-subscribe/route.ts
@@ -6,7 +6,7 @@ import { sendAssociationEmail } from "@/app/utils/email"; // Import email utilit
 
 export async function POST(req: NextRequest) {
   console.log("🚀 PayFast Subscription Request Received");
-  const notifyUrl = process.env.PAYFAST_NOTIFY_URL || "https://4fbf-13-71-3-101.ngrok-free.app/api/payfast-webhook";
+  const notifyUrl = process.env.PAYFAST_NOTIFY_URL || "https://966a-4-240-39-194.ngrok-free.app/api/payfast-webhook";
 
   const merchantId = process.env.PAYFAST_MERCHANT_ID || "10037398";
   const merchantKey = process.env.PAYFAST_MERCHANT_KEY || "u4xw2uwnuthmh";
@@ -54,8 +54,8 @@ export async function POST(req: NextRequest) {
   const paymentData: [string, string][] = [
     ["merchant_id", merchantId],
     ["merchant_key", merchantKey],
-    ["return_url", "https://4fbf-13-71-3-101.ngrok-free.app/success"],
-    ["cancel_url", "https://4fbf-13-71-3-101.ngrok-free.app/pricing"],
+    ["return_url", "https://966a-4-240-39-194.ngrok-free.app/success"],
+    ["cancel_url", "https://966a-4-240-39-194.ngrok-free.app/pricing"],
     ["notify_url", notifyUrl],
     ["name_first", "Pocket Agency"],
     ["name_last", "Subscription"],

--- a/frontend/src/app/api/payfast-subscribe/route.ts
+++ b/frontend/src/app/api/payfast-subscribe/route.ts
@@ -6,7 +6,7 @@ import { sendAssociationEmail } from "@/app/utils/email"; // Import email utilit
 
 export async function POST(req: NextRequest) {
   console.log("🚀 PayFast Subscription Request Received");
-  const notifyUrl = process.env.PAYFAST_NOTIFY_URL || "https://966a-4-240-39-194.ngrok-free.app/api/payfast-webhook";
+  const notifyUrl = process.env.PAYFAST_NOTIFY_URL || "https://ecc6-13-71-3-98.ngrok-free.app/api/payfast-webhook";
 
   const merchantId = process.env.PAYFAST_MERCHANT_ID || "10037398";
   const merchantKey = process.env.PAYFAST_MERCHANT_KEY || "u4xw2uwnuthmh";
@@ -54,8 +54,8 @@ export async function POST(req: NextRequest) {
   const paymentData: [string, string][] = [
     ["merchant_id", merchantId],
     ["merchant_key", merchantKey],
-    ["return_url", "https://966a-4-240-39-194.ngrok-free.app/success"],
-    ["cancel_url", "https://966a-4-240-39-194.ngrok-free.app/pricing"],
+    ["return_url", "https://ecc6-13-71-3-98.ngrok-free.app/success"],
+    ["cancel_url", "https://ecc6-13-71-3-98.ngrok-free.app/pricing"],
     ["notify_url", notifyUrl],
     ["name_first", "Pocket Agency"],
     ["name_last", "Subscription"],

--- a/frontend/src/app/associate-account/page.tsx
+++ b/frontend/src/app/associate-account/page.tsx
@@ -9,7 +9,7 @@ import { collection, query, where, getDocs, doc, updateDoc, setDoc } from "fireb
 export default function AssociateAccount() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [fullName, setFullName] = useState(""); // New field
+  const [fullName, setFullName] = useState("");
   const [isNewUser, setIsNewUser] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
@@ -30,11 +30,10 @@ export default function AssociateAccount() {
         if (!fullName) throw new Error("Full name is required for new users.");
         const userCredential = await createUserWithEmailAndPassword(auth, email, password);
         userId = userCredential.user.uid;
-        // Store user details
         await setDoc(doc(db, "users", userId), {
           email,
           fullName,
-          onboardingCompleted: false, // Set to false initially
+          onboardingCompleted: false,
         }, { merge: true });
       } else {
         const userCredential = await signInWithEmailAndPassword(auth, email, password);
@@ -44,8 +43,8 @@ export default function AssociateAccount() {
       console.log("Token from URL:", token);
       const q = query(
         collection(db, "subscriptions"),
-        where("associationToken", "==", token),
-        where("temp", "==", true)
+        where("associationToken", "==", token)
+        // Removed: where("temp", "==", true)
       );
       const querySnapshot = await getDocs(q);
 

--- a/frontend/src/app/utils/email.ts
+++ b/frontend/src/app/utils/email.ts
@@ -1,28 +1,27 @@
 // src/app/utils/email.ts
 import nodemailer from "nodemailer";
 
-export async function sendAssociationEmail(to: string, associationLink: string) {
+export async function sendAssociationEmail(to: string, message: string, subject = "Associate Your Pocket Agency Account") {
   const transporter = nodemailer.createTransport({
-    service: "gmail",
+    host: process.env.EMAIL_HOST, // smtp.gmail.com
+    port: Number(process.env.EMAIL_PORT), // 465
+    secure: true, // Use SSL
     auth: {
-      user: process.env.EMAIL_USER,
-      pass: process.env.EMAIL_PASS,
+      user: process.env.EMAIL_USER, // ruic7777@gmail.com
+      pass: process.env.EMAIL_PASS, // Gmail App Password
     },
   });
 
   const mailOptions = {
-    from: process.env.EMAIL_USER,
+    from: process.env.EMAIL_FROM || "ruic7777@gmail.com",
     to,
-    subject: "Associate Your Pocket Agency Subscription",
-    text: `Please click the link to associate your account: ${associationLink}`,
-    html: `<p>Please click the link to associate your account: <a href="${associationLink}">${associationLink}</a></p>`,
+    subject,
+    text: message,
   };
 
-  try {
-    await transporter.sendMail(mailOptions);
-    console.log("Association email sent successfully to:", to);
-  } catch (error) {
-    console.error("Failed to send association email:", error);
-    throw new Error("Failed to send association email");
-  }
+  await transporter.sendMail(mailOptions);
+}
+
+export async function sendEmail(to: string, subject: string, message: string) {
+  return sendAssociationEmail(to, message, subject);
 }


### PR DESCRIPTION
Implements automatic subscription cancellation for failed payments.
- Handles initial payment failures by setting status to "failed" and notifying the customer to retry.
- Handles recurring payment failures with a 24-hour retry mechanism (2 attempts before cancellation).
- Includes signature verification for security.
- Sends appropriate email notifications.
- Tested with Scenarios 1 (initial and recurring failures), 2 (payment success), and 3 (invalid signature).
Note: PayFast cancellation API fails with a 419 error in the sandbox due to an invalid test token; this will work in production with a real token.